### PR TITLE
When there are failed jobs, spark can't apply and release executor

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -635,9 +635,14 @@ private[spark] class ExecutorAllocationManager(
         if (stageIdToNumTasks.isEmpty) {
           allocationManager.onSchedulerQueueEmpty()
           if (numRunningTasks != 0) {
-            logWarning("No stages are running, but numRunningTasks != 0")
+            logWarning(s"No stages are running, but numRunningTasks = ${numRunningTasks}")
             numRunningTasks = 0
           }
+          executorIdToTaskIds.clear()
+          executorIds.filter(listener.isExecutorIdle).foreach(onExecutorIdle)
+        } else {
+          logDebug(s"There are ${stageIdToNumTasks.size} stages(" +
+            s"${stageIdToNumTasks.keySet.mkString(",")}), ${numRunningTasks} tasks are running.")
         }
       }
     }
@@ -675,7 +680,12 @@ private[spark] class ExecutorAllocationManager(
       val taskIndex = taskEnd.taskInfo.index
       val stageId = taskEnd.stageId
       allocationManager.synchronized {
-        numRunningTasks -= 1
+        if (numRunningTasks > 0) {
+          numRunningTasks -= 1
+        } else {
+          logInfo("Received SparkListenerTaskEnd event, but numRunningTasks == 0")
+        }
+
         // If the executor is no longer running any scheduled tasks, mark it as idle
         if (executorIdToTaskIds.contains(executorId)) {
           executorIdToTaskIds(executorId) -= taskId


### PR DESCRIPTION
## What changes were proposed in this pull request?
When there are failed jobs, spark can't apply and release executor
