### PR TITLE
Fix Competition when removing executor

### DIFF
--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -580,6 +580,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
               s"$numPendingExecutors pending, ${executorsPendingToRemove.size} removing")
             doRequestTotalExecutors(
               numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size)
+          } else {
+            Future.successful(true)
           }
         } else {
           numPendingExecutors += knownExecutors.size

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -575,8 +575,12 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
       // take into account executors that are pending to be added or removed.
       val adjustTotalExecutors =
         if (!replace) {
-          doRequestTotalExecutors(
-            numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size)
+          if (!Utils.isDynamicAllocationEnabled(conf)) {
+            logDebug(s"Sync with master, $numExistingExecutors existing , " +
+              s"$numPendingExecutors pending, ${executorsPendingToRemove.size} removing")
+            doRequestTotalExecutors(
+              numExistingExecutors + numPendingExecutors - executorsPendingToRemove.size)
+          }
         } else {
           numPendingExecutors += knownExecutors.size
           Future.successful(true)


### PR DESCRIPTION
## What changes were proposed in this pull request?
When dynamic allocation is enabled, there is a competition bewteen CoarseGrainedSchedulerBackend.scala and ExecutorAllocationManager.scala
 