### PR TITLE
sc.parallelize to compute splits instead of multi-thread

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/ParallelUnionHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ParallelUnionHadoopRDD.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import scala.reflect.ClassTag
+
+import org.apache.hadoop.conf.Configurable
+import org.apache.hadoop.io.Writable
+import org.apache.hadoop.mapred.{InputFormat, InputSplit, JobConf}
+import org.apache.hadoop.util.ReflectionUtils
+
+import org.apache.spark._
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.util.SerializableConfiguration
+
+
+
+
+case class PartitionInfo(path: String, ifc: Class[InputFormat[Writable, Writable]])
+
+private[spark] class ParallelUnionHadoopRDD[T: ClassTag](
+    @transient sc: SparkContext,
+    rdds: Seq[RDD[T]],
+    broadcastedConf: Broadcast[SerializableConfiguration],
+    initLocalJobConfFuncOpt: Option[(String, JobConf) => Unit],
+    partitionInfos: Seq[PartitionInfo]) extends UnionRDD[T](sc, rdds) {
+
+  val threshold = sc.conf.getInt("spark.rdd.parallelPartitionsThreshold", 31)
+
+  override def getPartitions: Array[Partition] = {
+    // select the latest partition input format class
+    val className = partitionInfos.last.ifc.getName
+    if (partitionInfos.size > threshold) {
+      // Create local references so that the outer object isn't serialized.
+      val rddIdMap = rdds.zipWithIndex.map(x => x._2 -> x._1.firstParent.firstParent.id).toMap
+      val broadcastedJobConf = broadcastedConf
+      val initJobConfFuncOpt = initLocalJobConfFuncOpt
+      val partitionsWithIndex = partitionInfos.zipWithIndex.toArray
+
+      val rddIndexWithPartitions =
+        sc.parallelize(partitionsWithIndex, partitionInfos.size).map { case (part, index) =>
+          val jobConfCacheKey = "rdd_%d_job_conf".format(rddIdMap(index))
+          val conf = broadcastedJobConf.value.value
+          val jobConf = new JobConf(conf)
+          initJobConfFuncOpt.map(f => f(part.path, jobConf))
+          HadoopRDD.putCachedMetadata(jobConfCacheKey, jobConf)
+          SparkHadoopUtil.get.addCredentials(jobConf)
+
+          val inputFormat =
+            ReflectionUtils.newInstance(part.ifc.asInstanceOf[Class[_]], jobConf)
+              .asInstanceOf[InputFormat[Writable, Writable]]
+          inputFormat match {
+            case c: Configurable => c.setConf(jobConf)
+            case _ =>
+          }
+          val inputSplits = inputFormat.getSplits(jobConf, 1)
+          val array = new Array[HadoopPartition](inputSplits.size)
+          for (i <- 0 until inputSplits.size) {
+            array(i) = new HadoopPartition(rddIdMap(index), i,
+              new SerializableWritable[InputSplit](inputSplits(i)))
+          }
+          new SerializableHadoopPartition(index, array)
+        }.collect()
+
+      val array = new Array[Partition](rddIndexWithPartitions.map(_.splits.size).sum)
+      var pos = 0
+
+      rddIndexWithPartitions.foreach { s =>
+        val rddIndex = s.rddIndex
+        val splits = s.splits
+        val rdd = rdds(rddIndex)
+        // UnionRDD's -> firstParent -> firstParent is HadoopRDD
+        val hadoopRDD = rdd.firstParent.firstParent
+        hadoopRDD.setPartitions(splits.asInstanceOf[Array[Partition]])
+        splits.foreach { part =>
+          array(pos) = new UnionPartition(pos, rdd, rddIndex, part.index)
+          pos += 1
+        }
+      }
+      array
+    } else {
+      super.getPartitions
+    }
+  }
+
+}

--- a/core/src/main/scala/org/apache/spark/rdd/ParallelUnionHadoopRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/ParallelUnionHadoopRDD.scala
@@ -46,7 +46,9 @@ private[spark] class ParallelUnionHadoopRDD[T: ClassTag](
   override def getPartitions: Array[Partition] = {
     // select the latest partition input format class
     val className = partitionInfos.last.ifc.getName
-    if (partitionInfos.size > threshold) {
+    if (partitionInfos.size > threshold &&
+      (className == "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat" ||
+        className == "org.apache.parquet.hadoop.ParquetInputFormat")) {
       // Create local references so that the outer object isn't serialized.
       val rddIdMap = rdds.zipWithIndex.map(x => x._2 -> x._1.firstParent.firstParent.id).toMap
       val broadcastedJobConf = broadcastedConf

--- a/core/src/main/scala/org/apache/spark/rdd/SerializableHadoopPartition.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/SerializableHadoopPartition.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import java.io.{ObjectInputStream, ObjectOutputStream}
+
+import org.apache.spark.util.Utils
+
+class SerializableHadoopPartition(var rddIndex: Int, var splits: Array[HadoopPartition])
+  extends Serializable {
+
+  private def writeObject(out: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    out.writeInt(rddIndex)
+    out.writeObject(splits)
+  }
+
+  private def readObject(in: ObjectInputStream): Unit = Utils.tryOrIOException {
+    rddIndex = in.readInt()
+    splits = in.readObject().asInstanceOf[Array[HadoopPartition]]
+  }
+}

--- a/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
+++ b/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala
@@ -117,7 +117,7 @@ class KryoSerializer(conf: SparkConf)
     kryo.register(classOf[SerializableConfiguration], new KryoJavaSerializer())
     kryo.register(classOf[SerializableJobConf], new KryoJavaSerializer())
     kryo.register(classOf[PythonBroadcast], new KryoJavaSerializer())
-
+    kryo.register(classOf[SerializableHadoopPartition], new KryoJavaSerializer())
     kryo.register(classOf[GenericRecord], new GenericAvroSerializer(avroSchemas))
     kryo.register(classOf[GenericData.Record], new GenericAvroSerializer(avroSchemas))
 

--- a/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/PipedRDDSuite.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.{LongWritable, Text}
-import org.apache.hadoop.mapred.{FileSplit, JobConf, TextInputFormat}
+import org.apache.hadoop.mapred.{InputSplit, FileSplit, JobConf, TextInputFormat}
 
 import org.apache.spark._
 import org.apache.spark.util.Utils
@@ -254,7 +254,7 @@ class PipedRDDSuite extends SparkFunSuite with SharedSparkContext {
   def generateFakeHadoopPartition(): HadoopPartition = {
     val split = new FileSplit(new Path("/some/path"), 0, 1,
       Array[String]("loc1", "loc2", "loc3", "loc4", "loc5"))
-    new HadoopPartition(sc.newRddId(), 1, split)
+    new HadoopPartition(sc.newRddId(), 1, new SerializableWritable[InputSplit](split))
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
sc.parallelize to compute splits instead of multi-thread