### PR TITLE
Do not fresh schema after write

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/DataFrameWriter.scala
@@ -212,7 +212,7 @@ final class DataFrameWriter[T] private[sql](ds: Dataset[T]) {
       bucketSpec = getBucketSpec,
       options = extraOptions.toMap)
 
-    dataSource.write(mode, df)
+    dataSource.write(mode, df, isForWriteOnly = true)
   }
   /**
    * Inserts the content of the `DataFrame` to the specified table. It requires that

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/createDataSourceTables.scala
@@ -224,7 +224,9 @@ case class CreateDataSourceTableAsSelectCommand(
       catalogTable = Some(table))
 
     val result = try {
-      dataSource.write(mode, df)
+      dataSource.write(mode, df).getOrElse {
+        throw new AnalysisException(s"Expected a BaseRelation but found None")
+      }
     } catch {
       case ex: AnalysisException =>
         logError(s"Failed to write to table $tableName in $mode mode", ex)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -415,15 +415,16 @@ case class DataSource(
 
   /** Writes the given [[DataFrame]] out to this [[DataSource]]. */
   def write(
-      mode: SaveMode,
-      data: DataFrame): BaseRelation = {
+             mode: SaveMode,
+             data: DataFrame,
+             isForWriteOnly: Boolean = false): Option[BaseRelation] = {
     if (data.schema.map(_.dataType).exists(_.isInstanceOf[CalendarIntervalType])) {
       throw new AnalysisException("Cannot save interval data type into external storage.")
     }
 
     providingClass.newInstance() match {
       case dataSource: CreatableRelationProvider =>
-        dataSource.createRelation(sparkSession.sqlContext, mode, caseInsensitiveOptions, data)
+        Some(dataSource.createRelation(sparkSession.sqlContext, mode, caseInsensitiveOptions, data))
       case format: FileFormat =>
         // Don't glob path for the write path.  The contracts here are:
         //  1. Only one output path can be specified on the write path;
@@ -491,7 +492,11 @@ case class DataSource(
             catalogTable = catalogTable)
         sparkSession.sessionState.executePlan(plan).toRdd
         // Replace the schema with that of the DataFrame we just wrote out to avoid re-inferring it.
-        copy(userSpecifiedSchema = Some(data.schema.asNullable)).resolveRelation()
+        if (isForWriteOnly && !sparkSession.sessionState.conf.freshSchemaAfterWrite) {
+          None
+        } else {
+          Some(copy(userSpecifiedSchema = Some(data.schema.asNullable)).resolveRelation())
+        }
 
       case _ =>
         sys.error(s"${providingClass.getCanonicalName} does not allow create table as select.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -415,9 +415,9 @@ case class DataSource(
 
   /** Writes the given [[DataFrame]] out to this [[DataSource]]. */
   def write(
-             mode: SaveMode,
-             data: DataFrame,
-             isForWriteOnly: Boolean = false): Option[BaseRelation] = {
+      mode: SaveMode,
+      data: DataFrame,
+      isForWriteOnly: Boolean = false): Option[BaseRelation] = {
     if (data.schema.map(_.dataType).exists(_.isInstanceOf[CalendarIntervalType])) {
       throw new AnalysisException("Cannot save interval data type into external storage.")
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -353,6 +353,11 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val WRITE_REFRESH_SCHEMA = SQLConfigBuilder("spark.sql.sources.write.refreshSchema.enabled")
+    .doc("When true, after write to datasource we will fresh schema by reading all files")
+    .booleanConf
+    .createWithDefault(false)
+
   val CROSS_JOINS_ENABLED = SQLConfigBuilder("spark.sql.crossJoin.enabled")
     .doc("When false, we will throw an error if a query contains a cartesian product without " +
         "explicit CROSS JOIN syntax.")
@@ -786,6 +791,8 @@ private[sql] class SQLConf extends Serializable with CatalystConf with Logging {
     getConf(SQLConf.PARALLEL_PARTITION_DISCOVERY_PARALLELISM)
 
   def bucketingEnabled: Boolean = getConf(SQLConf.BUCKETING_ENABLED)
+
+  def freshSchemaAfterWrite: Boolean = getConf(SQLConf.WRITE_REFRESH_SCHEMA)
 
   def dataFrameSelfJoinAutoResolveAmbiguity: Boolean =
     getConf(DATAFRAME_SELF_JOIN_AUTO_RESOLVE_AMBIGUITY)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Do not fresh schema after write
通过配置项来设置dataframe进行save的时候, 不读所有文件获取schema